### PR TITLE
Add ability to change root directory

### DIFF
--- a/bin/tree
+++ b/bin/tree
@@ -65,4 +65,4 @@ var cli = meow({
   ]
 });
 
-tree.make(cli.flags);
+tree.make(cli);

--- a/tree.js
+++ b/tree.js
@@ -386,7 +386,20 @@ var Promise = require('bluebird'),
 
   },
 
-  make = function (flags) {
+  make = function (cli) {
+
+    var input = cli.input;
+    var flags = cli.flags;
+
+    if (input.length > 0) {
+      var rootPath = input.shift();
+      if (fs.existsSync(rootPath)) {
+        _root = rootPath;
+      } else {
+        _error(`Directory '${rootPath}' doesn't exist`);
+        process.exit(-1);
+      }
+    }
 
     init(flags)
       .then(function () {


### PR DESCRIPTION
Currently invoking `treee <directory>` doesn't work which is inconsistent with how original `tree` works and makes it uncomfortable to traverse directories.

This PR adds ability to change the root directory.